### PR TITLE
Ensure the version of HDBSCAN is larger than 0.8.40

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ open3d==0.19.0
 opencv-python
 tqdm
 pillow
-hdbscan
+hdbscan>=0.8.41
 gdown
 
 # model


### PR DESCRIPTION
The version of HDBSCAN less than 0.8.40 lacks support for the force_all_finite keyword in check_array(), the call at https://github.com/cvg/FrontierNet/blob/66bbc8962820677c46b118d92296abd53ded17df/frontier/detector.py#L283 raises:

```python
TypeError: check_array() got an unexpected keyword argument 'force_all_finite'
```
However, this exception is silently caught and ignored at https://github.com/cvg/FrontierNet/blob/66bbc8962820677c46b118d92296abd53ded17df/frontier/detector.py#L286, resulting only in a misleading "no frontiers detected" log.